### PR TITLE
Fix misaligned unpacking in release functions

### DIFF
--- a/rust/src/arc.rs
+++ b/rust/src/arc.rs
@@ -549,7 +549,7 @@ impl<T> OptionalArcCell<T> {
 
 #[inline(always)]
 fn release<const NULLABLE: bool, T>(value: usize) {
-  let (ptr, _, weight) = unpack::<T>(value);
+  let (ptr, weight, _) = unpack::<T>(value);
   if NULLABLE && ptr.is_null() {
     return;
   }
@@ -558,7 +558,7 @@ fn release<const NULLABLE: bool, T>(value: usize) {
 
 #[inline(always)]
 fn release_to_arc<const NULLABLE: bool, T>(value: usize) -> Option<Arc<T>> {
-  let (ptr, _, weight) = unpack::<T>(value);
+  let (ptr, weight, _) = unpack::<T>(value);
   if NULLABLE && ptr.is_null() {
     return None;
   }


### PR DESCRIPTION
While reviewing your tagged pointer implementation, I found a minor mistake in unpacking the tag value that can cause memory leaks.

Specifically, some drop logs (e.g., `Drop 2903`) do not appear in the latest commit.

<details>
  <summary>Wrong Output (latest, 984eca8)</summary>

  ```text
1
2
  0
  65536
  131072
  196608
  262144
  327680
  393216
  458752
  524288
  589824
  655360
  720896
3
cas false
Drop 20000
4
5
None
Some(LogDrop { value: 10001 })
Drop 10001
Some(LogDrop { value: 10002 })
Drop 10002
Some(LogDrop { value: 10003 })
Drop 10003
6
Drop 10004
7
Drop 12345678
  ```
</details>

<details>
  <summary>Original Output (2f930f6)</summary>

  ```text
1
2
  0
  65536
  131072
  196608
  262144
  327680
  393216
  458752
  524288
  589824
  655360
  720896
3
cas false
Drop 20000
Drop 2903
Drop 20001
4
Drop 20002
5
None
Some(LogDrop { value: 10001 })
Drop 10001
Some(LogDrop { value: 10002 })
Drop 10002
Some(LogDrop { value: 10003 })
Drop 10003
6
Drop 10004
7
Drop 12345678
  ```
</details>

I discovered that the position of the `weight` value in the `release` functions is incorrect. This commit fixes the output to match commit 2f930f6.